### PR TITLE
Feature/21 Macros for Model Instances

### DIFF
--- a/config/models.json
+++ b/config/models.json
@@ -38,7 +38,7 @@
     },
     "text_recognition_latin": {
         "url": "https://paddle-model-ecology.bj.bcebos.com/paddlex/official_inference_model/paddle3.0.0//latin_PP-OCRv5_mobile_rec_infer.tar",
-        "languages": ["english", "spanish", "french", "german", "italian", "portuguese", "dutch", "turkish", "indonesian", "malay", "vietnamese", "tagalog", "swahili", "swedish", "norwegian", "danish", "finnish", "hungarian", "romanian", "catalan", "basque", "welsh", "irish", "icelandic", "latvian", "lithuanian", "estonian", "maltese", "afrikaans", "zulu", "xhosa", "somali", "hausa", "yoruba", "igbo", "albanian", "azerbaijani", "esperanto", "ganda", "latin", "maori", "shona", "sotho", "tsonga", "tswana", "bokmal", "nynorsk"],
+        "languages": ["english", "spanish", "french", "german", "italian", "portuguese", "dutch", "turkish", "indonesian", "malay", "vietnamese", "tagalog", "swahili", "swedish", "danish", "finnish", "hungarian", "romanian", "catalan", "basque", "welsh", "irish", "icelandic", "latvian", "lithuanian", "estonian", "afrikaans", "zulu", "xhosa", "somali", "yoruba", "albanian", "azerbaijani", "esperanto", "ganda", "latin", "maori", "shona", "sotho", "tsonga", "tswana", "bokmal", "nynorsk"],
         "is_script_model": true,
         "dir": "latin_PP-OCRv5_mobile_rec_infer",
         "output": "text_recognition_latin.onnx",
@@ -88,7 +88,7 @@
     },
     "text_recognition_cyrillic": {
         "url": "https://paddle-model-ecology.bj.bcebos.com/paddlex/official_inference_model/paddle3.0.0/cyrillic_PP-OCRv5_mobile_rec_infer.tar",
-        "languages": ["russian", "ukrainian", "belarusian", "bulgarian", "macedonian", "kazakh", "kyrgyz", "tajik", "mongolian", "bashkir", "chechen", "ossetic", "abkhaz", "avar", "buryat", "kabardian", "kalmyk", "komi", "mari", "tatar", "tuvan", "udmurt", "yakut"],
+        "languages": ["russian", "ukrainian", "belarusian", "bulgarian", "macedonian", "kazakh", "mongolian"],
         "is_script_model": true,
         "dir": "cyrillic_PP-OCRv5_mobile_rec_infer",
         "output": "text_recognition_cyrillic.onnx",
@@ -98,7 +98,7 @@
     },
     "text_recognition_devanagari": {
         "url": "https://paddle-model-ecology.bj.bcebos.com/paddlex/official_inference_model/paddle3.0.0/devanagari_PP-OCRv5_mobile_rec_infer.tar",
-        "languages": ["hindi", "marathi", "nepali", "sanskrit", "konkani", "bodo", "dogri", "maithili", "kashmiri", "sindhi", "santali"],
+        "languages": ["hindi", "marathi"],
         "is_script_model": true,
         "dir": "devanagari_PP-OCRv5_mobile_rec_infer",
         "output": "text_recognition_devanagari.onnx",
@@ -108,7 +108,7 @@
     },
     "text_recognition_te": {
         "url": "https://paddle-model-ecology.bj.bcebos.com/paddlex/official_inference_model/paddle3.0.0/te_PP-OCRv5_mobile_rec_infer.tar",
-        "languages": ["telegu"],
+        "languages": ["telugu"],
         "is_script_model": true,
         "dir": "te_PP-OCRv5_mobile_rec_infer",
         "output": "text_recognition_te.onnx",

--- a/scripts/download_models.py
+++ b/scripts/download_models.py
@@ -259,6 +259,11 @@ def main():
         type=str, 
         help="Download models for specific language only (e.g., 'english', 'chinese'). Models without language property are always downloaded."
     )
+    parser.add_argument(
+        "--generate-lang-config",
+        action="store_true",
+        help="Only generate the ocr_lang_models.json config file without downloading any models."
+    )
     args = parser.parse_args()
     
     models_config_path = Path(__file__).parent.parent / "config" / "models.json"
@@ -266,19 +271,24 @@ def main():
     
     models_to_process = filter_models_by_language(models, args.language)
     
+    base_dir = Path(__file__).parent.parent
+    models_dir = base_dir / "models"
+    
+    if args.generate_lang_config:
+        print("Generating language models config only...")
+        generate_ocr_lang_models_config(models_dir, models_to_process)
+        return
+    
     if args.language:
         print(f"Filtering models for language: {args.language}")
         print(f"Models to process: {list(models_to_process.keys())}")
     else:
         print("Processing all models")
     
-    base_dir = Path(__file__).parent.parent
-    
     for model_name, model_info in models_to_process.items():
         processor = get_processor(model_name, model_info, base_dir)
         processor.process()
     
-    models_dir = base_dir / "models"
     generate_ocr_lang_models_config(models_dir, models_to_process)
 
     download_dir = models_dir / "download"

--- a/src/document/analysis/pipeline.rs
+++ b/src/document/analysis/pipeline.rs
@@ -662,11 +662,10 @@ impl AnalysisPipeline {
                     .map_err(|source| DocumentError::ModelProcessingError { source })?;
                 debug!(
                     "Detected language from embedded text: {}",
-                    detection_result.language
+                    detection_result.language_name()
                 );
-                let detected_lang = detection_result.get_language();
-                *language_cache = Some(detected_lang);
-                detected_lang
+                *language_cache = Some(detection_result.language);
+                detection_result.language
             }
         };
 
@@ -836,11 +835,11 @@ impl AnalysisPipeline {
                         .map_err(|source| DocumentError::ModelProcessingError { source })?;
                 debug!(
                     "Detected language: {} (confidence: {:.2})",
-                    detection_result.language, detection_result.confidence
+                    detection_result.language_name(),
+                    detection_result.confidence
                 );
-                let detected_lang = detection_result.get_language();
-                *language_cache = Some(detected_lang);
-                detected_lang
+                *language_cache = Some(detection_result.language);
+                detection_result.language
             }
         };
 

--- a/src/document/analysis/pipeline.rs
+++ b/src/document/analysis/pipeline.rs
@@ -915,12 +915,6 @@ impl AnalysisPipeline {
             all_qa_results.extend(page.question_answers.clone());
         }
 
-        if let Ok(removed) = Crnn::cleanup_except(language) {
-            if removed > 0 {
-                debug!("Cleaned up {} dynamically loaded CRNN model(s)", removed);
-            }
-        }
-
         Ok(all_qa_results)
     }
 }

--- a/src/document/mod.rs
+++ b/src/document/mod.rs
@@ -26,8 +26,8 @@ pub use error::DocumentError;
 pub use layout_box::{LayoutBox, LayoutClass};
 pub use text_box::TextBox;
 
-use crate::utils::lang_utils::LangUtils;
 use content::{CsvContent, ExcelContent, PdfContent, TextContent, WordContent};
+use lingua::Language;
 
 /// Represents a loaded document that can be analyzed for content extraction.
 ///
@@ -130,7 +130,7 @@ impl Document {
     ///
     /// * `questions` - Optional slice of questions to answer about the document
     /// * `process_id` - Unique identifier for this analysis process (used for logging/tracking)
-    /// * `language` - Optional language hint for OCR (e.g., "en", "ch", "arabic")
+    /// * `language` - Optional language hint for OCR
     ///
     /// # Returns
     ///
@@ -141,7 +141,7 @@ impl Document {
         &mut self,
         questions: Option<&[String]>,
         process_id: &str,
-        language: Option<&str>,
+        language: Option<Language>,
     ) -> Result<(), DocumentError> {
         self.process_id = process_id.to_string();
         let doc_type = self.doc_type.clone();
@@ -155,8 +155,7 @@ impl Document {
         };
 
         let questions = questions.unwrap_or(&[]);
-        let language_enum = language.and_then(LangUtils::parse_language);
-        let question_answers = pipeline.analyze(content, questions, language_enum)?;
+        let question_answers = pipeline.analyze(content, questions, language)?;
 
         self.question_answers = question_answers;
 

--- a/src/document/mod.rs
+++ b/src/document/mod.rs
@@ -26,6 +26,7 @@ pub use error::DocumentError;
 pub use layout_box::{LayoutBox, LayoutClass};
 pub use text_box::TextBox;
 
+use crate::utils::lang_utils::LangUtils;
 use content::{CsvContent, ExcelContent, PdfContent, TextContent, WordContent};
 
 /// Represents a loaded document that can be analyzed for content extraction.
@@ -154,7 +155,8 @@ impl Document {
         };
 
         let questions = questions.unwrap_or(&[]);
-        let question_answers = pipeline.analyze(content, questions, language.map(String::from))?;
+        let language_enum = language.and_then(LangUtils::parse_language);
+        let question_answers = pipeline.analyze(content, questions, language_enum)?;
 
         self.question_answers = question_answers;
 

--- a/src/inference/dbnet.rs
+++ b/src/inference/dbnet.rs
@@ -42,12 +42,6 @@ use crate::impl_simple_singleton;
 /// - `src_dimensions`: Original input image dimensions `[width, height]`
 /// - `dst_dimensions`: Processed image dimensions after padding `[width, height]`
 /// - `padding`: Applied padding `[top, bottom, left, right]`
-///
-/// # Thread Safety
-///
-/// This struct is wrapped in a `Mutex` and accessed through a singleton pattern,
-/// making it safe to use from multiple threads. However, only one thread can
-/// perform inference at a time.
 pub struct DBNet {
     session: Session,
     mean_values: [f32; 3],
@@ -60,6 +54,12 @@ pub struct DBNet {
     dst_dimensions: [i32; 2], // [width, height]
     padding: [i32; 4],        // [top, bottom, left, right]
 }
+
+impl_simple_singleton!(
+    model: DBNet,
+    instance: DBNET_INSTANCE,
+    init: || Self::new()
+);
 
 impl DBNet {
     /// Path to the DBNet ONNX model file.
@@ -587,9 +587,3 @@ impl DBNet {
         model.detect(&preprocessed)
     }
 }
-
-impl_simple_singleton!(
-    model: DBNet,
-    instance: DBNET_INSTANCE,
-    init: || Self::new()
-);

--- a/src/inference/lcnet.rs
+++ b/src/inference/lcnet.rs
@@ -18,7 +18,7 @@ use crate::inference::error::InferenceError;
 use crate::utils::config::AppConfig;
 use crate::utils::image_utils;
 
-use crate::impl_mode_singleton;
+use crate::impl_static_keyed_singleton;
 
 /// Operating mode for the LCNet classifier.
 ///
@@ -557,9 +557,9 @@ impl LCNet {
     }
 }
 
-impl_mode_singleton!(
+impl_static_keyed_singleton!(
     model: LCNet,
-    mode_type: LCNetMode,
+    key_type: LCNetMode,
     variants: {
         TextOrientation => TEXT_ORIENTATION_INSTANCE,
         DocumentOrientation => DOCUMENT_ORIENTATION_INSTANCE,

--- a/src/inference/lcnet.rs
+++ b/src/inference/lcnet.rs
@@ -73,6 +73,16 @@ pub struct LCNet {
     mode: LCNetMode,
 }
 
+impl_static_keyed_singleton!(
+    model: LCNet,
+    key_type: LCNetMode,
+    variants: {
+        TextOrientation => TEXT_ORIENTATION_INSTANCE,
+        DocumentOrientation => DOCUMENT_ORIENTATION_INSTANCE,
+        TableType => TABLE_CLASSIFICATION_INSTANCE,
+    }
+);
+
 impl LCNet {
     /// Path to the text orientation classification model.
     const TEXT_ORIENTATION_MODEL_PATH: &'static str = "onnx/text_orientation_classification.onnx";
@@ -556,13 +566,3 @@ impl LCNet {
         }
     }
 }
-
-impl_static_keyed_singleton!(
-    model: LCNet,
-    key_type: LCNetMode,
-    variants: {
-        TextOrientation => TEXT_ORIENTATION_INSTANCE,
-        DocumentOrientation => DOCUMENT_ORIENTATION_INSTANCE,
-        TableType => TABLE_CLASSIFICATION_INSTANCE,
-    }
-);

--- a/src/inference/mod.rs
+++ b/src/inference/mod.rs
@@ -4,6 +4,7 @@ pub mod error;
 pub mod lcnet;
 pub mod phi4mini;
 pub mod rtdetr;
+pub mod singleton;
 pub mod tasks;
 
 pub use error::InferenceError;

--- a/src/inference/rtdetr.rs
+++ b/src/inference/rtdetr.rs
@@ -20,7 +20,7 @@ use crate::inference::error::InferenceError;
 use crate::utils::config::AppConfig;
 use crate::utils::{box_utils, image_utils};
 
-use crate::impl_mode_singleton;
+use crate::impl_static_keyed_singleton;
 
 /// Operating mode for the RT-DETR detector.
 ///
@@ -428,9 +428,9 @@ impl RtDetr {
     }
 }
 
-impl_mode_singleton!(
+impl_static_keyed_singleton!(
     model: RtDetr,
-    mode_type: RtDetrMode,
+    key_type: RtDetrMode,
     variants: {
         Layout => LAYOUT_DETECTION_INSTANCE,
         WiredTableCell => WIRED_TABLE_CELL_DETECTION_INSTANCE,

--- a/src/inference/rtdetr.rs
+++ b/src/inference/rtdetr.rs
@@ -78,6 +78,16 @@ pub struct RtDetr {
     mode: RtDetrMode,
 }
 
+impl_static_keyed_singleton!(
+    model: RtDetr,
+    key_type: RtDetrMode,
+    variants: {
+        Layout => LAYOUT_DETECTION_INSTANCE,
+        WiredTableCell => WIRED_TABLE_CELL_DETECTION_INSTANCE,
+        WirelessTableCell => WIRELESS_TABLE_CELL_DETECTION_INSTANCE,
+    }
+);
+
 impl RtDetr {
     /// Path to the layout detection model.
     const LAYOUT_DETECTION_MODEL_PATH: &'static str = "onnx/layout_detection.onnx";
@@ -427,13 +437,3 @@ impl RtDetr {
         model.detect(&preprocessed)
     }
 }
-
-impl_static_keyed_singleton!(
-    model: RtDetr,
-    key_type: RtDetrMode,
-    variants: {
-        Layout => LAYOUT_DETECTION_INSTANCE,
-        WiredTableCell => WIRED_TABLE_CELL_DETECTION_INSTANCE,
-        WirelessTableCell => WIRELESS_TABLE_CELL_DETECTION_INSTANCE,
-    }
-);

--- a/src/inference/singleton.rs
+++ b/src/inference/singleton.rs
@@ -1,0 +1,134 @@
+//! Singleton pattern macros for inference models.
+//!
+//! This module provides macros to reduce boilerplate when implementing the singleton
+//! pattern for inference models. Models are wrapped in `Mutex` for thread-safe access
+//! and stored in `OnceCell` for lazy initialization.
+//!
+//! # Available Macros
+//!
+//! - [`impl_simple_singleton!`] - For models with a single global instance
+//! - [`impl_mode_singleton!`] - For models with separate instances per operating mode
+
+/// Implements the singleton pattern for a simple inference model.
+///
+/// This macro generates:
+/// - A static `OnceCell<Mutex<$model>>` instance
+/// - A `get_or_init()` method for eager initialization
+/// - An `instance()` method for accessing the singleton
+///
+/// # Generated Methods
+///
+/// - `pub fn get_or_init() -> Result<(), InferenceError>` - Initializes the singleton
+/// - `fn instance() -> Result<&'static Mutex<Self>, InferenceError>` - Gets the singleton reference
+#[macro_export]
+macro_rules! impl_simple_singleton {
+    (
+        model: $model:ty,
+        instance: $instance:ident,
+        init: $init:expr
+    ) => {
+        static $instance: ::once_cell::sync::OnceCell<::std::sync::Mutex<$model>> =
+            ::once_cell::sync::OnceCell::new();
+
+        impl $model {
+            /// Pre-initializes the singleton instance.
+            ///
+            /// Call this method during application startup to eagerly load the model
+            /// rather than waiting for the first inference request.
+            ///
+            /// # Errors
+            ///
+            /// Returns an [`InferenceError`] if model initialization fails.
+            pub fn get_or_init() -> Result<(), $crate::inference::InferenceError> {
+                $instance.get_or_try_init(|| {
+                    let init_fn: fn() -> Result<Self, $crate::inference::InferenceError> = $init;
+                    init_fn().map(::std::sync::Mutex::new)
+                })?;
+                Ok(())
+            }
+
+            /// Returns a reference to the singleton instance.
+            ///
+            /// Initializes the instance if it hasn't been created yet.
+            fn instance(
+            ) -> Result<&'static ::std::sync::Mutex<Self>, $crate::inference::InferenceError> {
+                $instance.get_or_try_init(|| {
+                    let init_fn: fn() -> Result<Self, $crate::inference::InferenceError> = $init;
+                    init_fn().map(::std::sync::Mutex::new)
+                })
+            }
+        }
+    };
+}
+
+/// Implements the singleton pattern for a mode-based inference model.
+///
+/// This macro generates:
+/// - Static `OnceCell<Mutex<$model>>` instances for each mode variant
+/// - A `get_or_init(mode)` method for eager initialization of a specific mode
+/// - An `instance(mode)` method for accessing the singleton for a specific mode
+///
+/// # Generated Methods
+///
+/// - `pub fn get_or_init(mode: Mode) -> Result<(), InferenceError>` - Initializes singleton for mode
+/// - `fn instance(mode: Mode) -> Result<&'static Mutex<Self>, InferenceError>` - Gets singleton for mode
+#[macro_export]
+macro_rules! impl_mode_singleton {
+    (
+        model: $model:ty,
+        mode_type: $mode_type:ty,
+        variants: {
+            $($variant:ident => $instance:ident),+ $(,)?
+        }
+    ) => {
+        $(
+            static $instance: ::once_cell::sync::OnceCell<::std::sync::Mutex<$model>> =
+                ::once_cell::sync::OnceCell::new();
+        )+
+
+        impl $model {
+            /// Pre-initializes the singleton instance for the specified mode.
+            ///
+            /// Call this method during application startup to eagerly load models
+            /// rather than waiting for the first inference request.
+            ///
+            /// # Arguments
+            ///
+            /// * `mode` - The operating mode to initialize
+            ///
+            /// # Errors
+            ///
+            /// Returns an [`InferenceError`] if model initialization fails.
+            pub fn get_or_init(mode: $mode_type) -> Result<(), $crate::inference::InferenceError> {
+                match mode {
+                    $(
+                        <$mode_type>::$variant => {
+                            $instance.get_or_try_init(|| {
+                                Self::new(<$mode_type>::$variant).map(::std::sync::Mutex::new)
+                            })?;
+                        }
+                    )+
+                }
+                Ok(())
+            }
+
+            /// Returns a reference to the singleton instance for the specified mode.
+            ///
+            /// Initializes the instance if it hasn't been created yet.
+            fn instance(mode: $mode_type) -> Result<&'static ::std::sync::Mutex<Self>, $crate::inference::InferenceError> {
+                match mode {
+                    $(
+                        <$mode_type>::$variant => {
+                            $instance.get_or_try_init(|| {
+                                Self::new(<$mode_type>::$variant).map(::std::sync::Mutex::new)
+                            })
+                        }
+                    )+
+                }
+            }
+        }
+    };
+}
+
+pub use impl_mode_singleton;
+pub use impl_simple_singleton;

--- a/src/inference/singleton.rs
+++ b/src/inference/singleton.rs
@@ -7,8 +7,9 @@
 //! # Available Macros
 //!
 //! - [`impl_simple_singleton!`] - For models with a single global instance
-//! - [`impl_mode_singleton!`] - For models with separate instances per operating mode
-
+//! - [`impl_keyed_singleton!`] - For models with separate instances per key (e.g., mode, language)
+//! - [`impl_static_keyed_singleton!`] - For models with a fixed set of static variants
+///
 /// Implements the singleton pattern for a simple inference model.
 ///
 /// This macro generates:
@@ -61,22 +62,192 @@ macro_rules! impl_simple_singleton {
     };
 }
 
-/// Implements the singleton pattern for a mode-based inference model.
+/// Implements the singleton pattern for a keyed inference model.
+///
+/// This macro generates:
+/// - A static `OnceCell<RwLock<HashMap<K, Mutex<$model>>>>` for dynamic key-based singletons
+/// - A `get_or_init(key)` method for eager initialization of a specific key
+/// - An `instance(key)` method for accessing the singleton for a specific key
+///
+/// The key type must implement `Eq + Hash + Clone + Copy + Send + Sync + 'static`.
+///
+/// # Generated Methods
+///
+/// - `pub fn get_or_init(key: K) -> Result<(), InferenceError>` - Initializes singleton for key
+/// - `fn with_instance<F, R>(key: K, f: F) -> Result<R, InferenceError>` - Executes closure with locked instance
+#[macro_export]
+macro_rules! impl_keyed_singleton {
+    (
+        model: $model:ty,
+        key_type: $key_type:ty,
+        instance: $instance:ident
+    ) => {
+        static $instance: ::once_cell::sync::OnceCell<
+            ::std::sync::RwLock<::std::collections::HashMap<$key_type, ::std::sync::Mutex<$model>>>,
+        > = ::once_cell::sync::OnceCell::new();
+
+        impl $model {
+            /// Pre-initializes the singleton instance for the specified key.
+            ///
+            /// Call this method during application startup to eagerly load models
+            /// rather than waiting for the first inference request.
+            ///
+            /// # Arguments
+            ///
+            /// * `key` - The key (e.g., language, mode) to initialize
+            ///
+            /// # Errors
+            ///
+            /// Returns an [`InferenceError`] if model initialization fails.
+            pub fn get_or_init(key: $key_type) -> Result<(), $crate::inference::InferenceError> {
+                let map = $instance
+                    .get_or_init(|| ::std::sync::RwLock::new(::std::collections::HashMap::new()));
+
+                {
+                    let read_guard = map.read().map_err(|e| {
+                        $crate::inference::InferenceError::ProcessingError {
+                            message: format!("Failed to acquire read lock: {e}"),
+                        }
+                    })?;
+                    if read_guard.contains_key(&key) {
+                        return Ok(());
+                    }
+                }
+
+                let mut write_guard = map.write().map_err(|e| {
+                    $crate::inference::InferenceError::ProcessingError {
+                        message: format!("Failed to acquire write lock: {e}"),
+                    }
+                })?;
+
+                if !write_guard.contains_key(&key) {
+                    let model = Self::new(key)?;
+                    write_guard.insert(key, ::std::sync::Mutex::new(model));
+                }
+
+                Ok(())
+            }
+
+            /// Executes a closure with exclusive access to the model instance for the specified key.
+            ///
+            /// This method ensures thread-safe access to the model by acquiring the appropriate locks.
+            /// The model is initialized if it doesn't exist yet.
+            ///
+            /// # Arguments
+            ///
+            /// * `key` - The key identifying which model instance to use
+            /// * `f` - A closure that receives a mutable reference to the model
+            ///
+            /// # Returns
+            ///
+            /// The result of the closure, or an error if lock acquisition fails.
+            ///
+            /// # Errors
+            ///
+            /// Returns an [`InferenceError`] if:
+            /// - Model initialization fails
+            /// - Lock acquisition fails
+            pub fn with_instance<F, R>(
+                key: $key_type,
+                f: F,
+            ) -> Result<R, $crate::inference::InferenceError>
+            where
+                F: FnOnce(&mut Self) -> Result<R, $crate::inference::InferenceError>,
+            {
+                Self::get_or_init(key)?;
+
+                let map = $instance.get().ok_or_else(|| {
+                    $crate::inference::InferenceError::ProcessingError {
+                        message: "Instance map not initialized".to_string(),
+                    }
+                })?;
+
+                let read_guard =
+                    map.read()
+                        .map_err(|e| $crate::inference::InferenceError::ProcessingError {
+                            message: format!("Failed to acquire read lock: {e}"),
+                        })?;
+
+                let mutex = read_guard.get(&key).ok_or_else(|| {
+                    $crate::inference::InferenceError::ProcessingError {
+                        message: "Instance not found after initialization".to_string(),
+                    }
+                })?;
+
+                let mut model = mutex.lock().map_err(|e| {
+                    $crate::inference::InferenceError::ProcessingError {
+                        message: format!("Failed to lock model instance: {e}"),
+                    }
+                })?;
+
+                f(&mut model)
+            }
+
+            /// Removes all cached model instances except for the specified key.
+            ///
+            /// This method is useful for cleaning up dynamically loaded models while
+            /// preserving a pre-initialized default model (e.g., from CLI arguments).
+            ///
+            /// # Arguments
+            ///
+            /// * `keep_key` - Optional key to preserve. If `None`, all instances are removed.
+            ///
+            /// # Returns
+            ///
+            /// The number of instances that were removed.
+            ///
+            /// # Errors
+            ///
+            /// Returns an [`InferenceError`] if lock acquisition fails.
+            pub fn cleanup_except(
+                keep_key: Option<$key_type>,
+            ) -> Result<usize, $crate::inference::InferenceError> {
+                let Some(map) = $instance.get() else {
+                    return Ok(0);
+                };
+
+                let mut write_guard = map.write().map_err(|e| {
+                    $crate::inference::InferenceError::ProcessingError {
+                        message: format!("Failed to acquire write lock for cleanup: {e}"),
+                    }
+                })?;
+
+                let keys_to_remove: Vec<$key_type> = write_guard
+                    .keys()
+                    .filter(|k| keep_key.map_or(true, |keep| *k != &keep))
+                    .copied()
+                    .collect();
+
+                let count = keys_to_remove.len();
+                for key in keys_to_remove {
+                    write_guard.remove(&key);
+                }
+
+                Ok(count)
+            }
+        }
+    };
+}
+
+/// Implements the singleton pattern for a mode-based inference model with static variants.
 ///
 /// This macro generates:
 /// - Static `OnceCell<Mutex<$model>>` instances for each mode variant
 /// - A `get_or_init(mode)` method for eager initialization of a specific mode
 /// - An `instance(mode)` method for accessing the singleton for a specific mode
 ///
+/// Use this macro when you have a fixed, known set of variants at compile time.
+/// For dynamic keys (like Language enum with many variants), use `impl_keyed_singleton!`.
+///
 /// # Generated Methods
 ///
-/// - `pub fn get_or_init(mode: Mode) -> Result<(), InferenceError>` - Initializes singleton for mode
-/// - `fn instance(mode: Mode) -> Result<&'static Mutex<Self>, InferenceError>` - Gets singleton for mode
+/// - `pub fn get_or_init(key: K) -> Result<(), InferenceError>` - Initializes singleton for key
+/// - `fn instance(key: K) -> Result<&'static Mutex<Self>, InferenceError>` - Gets singleton for key
 #[macro_export]
-macro_rules! impl_mode_singleton {
+macro_rules! impl_static_keyed_singleton {
     (
         model: $model:ty,
-        mode_type: $mode_type:ty,
+        key_type: $key_type:ty,
         variants: {
             $($variant:ident => $instance:ident),+ $(,)?
         }
@@ -87,24 +258,24 @@ macro_rules! impl_mode_singleton {
         )+
 
         impl $model {
-            /// Pre-initializes the singleton instance for the specified mode.
+            /// Pre-initializes the singleton instance for the specified key.
             ///
             /// Call this method during application startup to eagerly load models
             /// rather than waiting for the first inference request.
             ///
             /// # Arguments
             ///
-            /// * `mode` - The operating mode to initialize
+            /// * `key` - The key (e.g., mode) to initialize
             ///
             /// # Errors
             ///
             /// Returns an [`InferenceError`] if model initialization fails.
-            pub fn get_or_init(mode: $mode_type) -> Result<(), $crate::inference::InferenceError> {
-                match mode {
+            pub fn get_or_init(key: $key_type) -> Result<(), $crate::inference::InferenceError> {
+                match key {
                     $(
-                        <$mode_type>::$variant => {
+                        <$key_type>::$variant => {
                             $instance.get_or_try_init(|| {
-                                Self::new(<$mode_type>::$variant).map(::std::sync::Mutex::new)
+                                Self::new(<$key_type>::$variant).map(::std::sync::Mutex::new)
                             })?;
                         }
                     )+
@@ -112,15 +283,15 @@ macro_rules! impl_mode_singleton {
                 Ok(())
             }
 
-            /// Returns a reference to the singleton instance for the specified mode.
+            /// Returns a reference to the singleton instance for the specified key.
             ///
             /// Initializes the instance if it hasn't been created yet.
-            fn instance(mode: $mode_type) -> Result<&'static ::std::sync::Mutex<Self>, $crate::inference::InferenceError> {
-                match mode {
+            fn instance(key: $key_type) -> Result<&'static ::std::sync::Mutex<Self>, $crate::inference::InferenceError> {
+                match key {
                     $(
-                        <$mode_type>::$variant => {
+                        <$key_type>::$variant => {
                             $instance.get_or_try_init(|| {
-                                Self::new(<$mode_type>::$variant).map(::std::sync::Mutex::new)
+                                Self::new(<$key_type>::$variant).map(::std::sync::Mutex::new)
                             })
                         }
                     )+
@@ -130,5 +301,6 @@ macro_rules! impl_mode_singleton {
     };
 }
 
-pub use impl_mode_singleton;
+pub use impl_keyed_singleton;
 pub use impl_simple_singleton;
+pub use impl_static_keyed_singleton;

--- a/src/inference/singleton.rs
+++ b/src/inference/singleton.rs
@@ -1,6 +1,6 @@
 //! Singleton pattern macros for inference models.
 //!
-//! This module provides macros to reduce boilerplate when implementing the singleton
+//! This module provides macros to when implementing the singleton
 //! pattern for inference models. Models are wrapped in `Mutex` for thread-safe access
 //! and stored in `OnceCell` for lazy initialization.
 //!

--- a/src/inference/tasks/question_and_answer_task.rs
+++ b/src/inference/tasks/question_and_answer_task.rs
@@ -64,22 +64,6 @@ impl QuestionAndAnswerResult {
 pub struct QuestionAndAnswerTask;
 
 impl QuestionAndAnswerTask {
-    /// Initializes the underlying model if not already loaded.
-    ///
-    /// This method should be called at application startup to preload the
-    /// language model, avoiding latency on the first question. The model
-    /// is cached globally and reused for subsequent calls.
-    ///
-    /// # Errors
-    ///
-    /// Returns an [`InferenceError`] if:
-    /// - The model files cannot be found or loaded
-    /// - The tokenizer fails to initialize
-    /// - There is insufficient memory to load the model
-    pub fn get_or_init() -> Result<(), InferenceError> {
-        Phi4MiniInference::init_all()
-    }
-
     /// Answers a question based on the provided document context.
     ///
     /// This method sends the context and question to the model,

--- a/src/inference/tasks/question_and_answer_task.rs
+++ b/src/inference/tasks/question_and_answer_task.rs
@@ -77,7 +77,7 @@ impl QuestionAndAnswerTask {
     /// - The tokenizer fails to initialize
     /// - There is insufficient memory to load the model
     pub fn get_or_init() -> Result<(), InferenceError> {
-        Phi4MiniInference::get_or_init()
+        Phi4MiniInference::init_all()
     }
 
     /// Answers a question based on the provided document context.

--- a/src/main.rs
+++ b/src/main.rs
@@ -65,7 +65,7 @@ async fn run_server(language: Option<Language>) -> Result<(), Box<dyn std::error
 
     initialize_models(language).await?;
 
-    server::start_server(socket_addr).await?;
+    server::start_server(socket_addr, language).await?;
 
     Ok(())
 }
@@ -116,6 +116,12 @@ async fn initialize_models(
             .ok_or_else(|| format!("Unsupported language: {}", lang_str))?;
 
         Crnn::get_or_init(model_info.model_file)?;
+    } else {
+        tracing::info!("  Loading CRNN models (OCR)...");
+        let model_groups = LangUtils::get_model_groups(false)?;
+        for (model_file, _) in model_groups {
+            Crnn::get_or_init(model_file)?;
+        }
     }
 
     tracing::info!("All models preloaded successfully.");

--- a/src/main.rs
+++ b/src/main.rs
@@ -111,7 +111,11 @@ async fn initialize_models(
     if let Some(language) = ocr_language {
         let lang_str = LangUtils::map_from_lingua_language(language);
         tracing::info!("  Loading Crnn ({} text recognition)...", lang_str);
-        Crnn::get_or_init(language)?;
+
+        let model_info = LangUtils::get_language_model_info(language)
+            .ok_or_else(|| format!("Unsupported language: {}", lang_str))?;
+
+        Crnn::get_or_init(model_info.model_file)?;
     }
 
     tracing::info!("All models preloaded successfully.");

--- a/src/main.rs
+++ b/src/main.rs
@@ -2,8 +2,8 @@ use clap::Parser;
 use docyoumeant::inference::crnn::Crnn;
 use docyoumeant::inference::dbnet::DBNet;
 use docyoumeant::inference::lcnet::{LCNet, LCNetMode};
+use docyoumeant::inference::phi4mini::Phi4MiniInference;
 use docyoumeant::inference::rtdetr::{RtDetr, RtDetrMode};
-use docyoumeant::inference::tasks::question_and_answer_task::QuestionAndAnswerTask;
 use docyoumeant::server;
 use docyoumeant::utils::config::AppConfig;
 use docyoumeant::utils::lang_utils::LangUtils;
@@ -106,7 +106,7 @@ async fn initialize_models(
     RtDetr::get_or_init(RtDetrMode::WirelessTableCell)?;
 
     tracing::info!("  Loading Phi4Mini (language model)...");
-    QuestionAndAnswerTask::get_or_init()?;
+    Phi4MiniInference::init_all()?;
 
     if let Some(language) = ocr_language {
         let lang_str = LangUtils::map_from_lingua_language(language);

--- a/src/utils/lang_utils.rs
+++ b/src/utils/lang_utils.rs
@@ -33,26 +33,27 @@ pub struct LanguageModelInfo {
 pub struct LangUtils;
 
 impl LangUtils {
-    /// Retrieves the configuration for a specific language.
+    /// Retrieves the information about the model for a specific language.
     ///
-    /// Looks up the language configuration from the JSON config file. If the config file
-    /// cannot be read and the requested language is "english", returns a default English
-    /// configuration as a fallback.
+    /// Looks up the language model info from the JSON model config file using the
+    /// Lingua `Language` enum. If the model config file cannot be read and the
+    /// requested language is English, returns a default English configuration as a fallback.
     ///
     /// # Arguments
     ///
-    /// * `language` - The name of the language to look up (e.g., "english", "chinese").
+    /// * `language` - The Lingua `Language` enum value to look up.
     ///
     /// # Returns
     ///
-    /// * `Some(LanguageConfig)` - The configuration for the requested language if found.
+    /// * `Some(LanguageModelInfo)` - The configuration for the requested language if found.
     /// * `None` - If the language is not supported or not found in the configuration.
-    pub fn get_language_config(language: &str) -> Option<LanguageModelInfo> {
+    pub fn get_language_model_info(language: Language) -> Option<LanguageModelInfo> {
+        let language_str = Self::map_from_lingua_language(language);
         let config = AppConfig::get();
         match Self::get_all_language_configs(false) {
-            Ok(configs) => configs.get(language).cloned(),
+            Ok(configs) => configs.get(&language_str).cloned(),
             Err(_) => {
-                if language == "english" {
+                if language == Language::English {
                     Some(LanguageModelInfo {
                         name: "english".to_string(),
                         model_file: config.model_path("onnx/text_recognition_en.onnx"),
@@ -64,6 +65,23 @@ impl LangUtils {
                 }
             }
         }
+    }
+
+    /// Parses a language string and returns the corresponding Lingua Language enum.
+    ///
+    /// This is useful for converting command-line arguments or configuration strings
+    /// to type-safe Language enum values.
+    ///
+    /// # Arguments
+    ///
+    /// * `language_str` - The language name string to parse (case-insensitive).
+    ///
+    /// # Returns
+    ///
+    /// * `Some(Language)` - The corresponding Lingua `Language` enum variant.
+    /// * `None` - If the language string is not recognized.
+    pub fn parse_language(language_str: &str) -> Option<Language> {
+        Self::map_to_lingua_language(language_str)
     }
 
     /// Retrieves all available language configurations.


### PR DESCRIPTION
Created a set of macros for initializing and retrieving model instances, and refined how (and which) models are loaded on startup.
- Moved ModelGroup from language_detection_task to lang_utils
- created impl_simple_singleton, impl_keyed_singleton, and impl_static_keyed_singleton for initializing and getting model instances
- Now loading all CRNN script models when no language argument is provided, to avoid cold start during language detection 
- refined supported languages, and arguments utilized to configure languages throughout the analysis pipeline